### PR TITLE
Add DB interface layer

### DIFF
--- a/config/paths.js
+++ b/config/paths.js
@@ -53,5 +53,6 @@ module.exports = {
     publicUrl: getPublicUrl(resolveApp("package.json")),
     servedPath: getServedPath(resolveApp("package.json")),
     server: resolveApp("./server"),
+    db: resolveApp("./db"),
     tmp: resolveApp("./server/.tmp"),
 };

--- a/db/ActionRepository/ActionModel.js
+++ b/db/ActionRepository/ActionModel.js
@@ -1,0 +1,28 @@
+const assert = require("assert");
+const { createValidPropertiesObject } = require("../helpers/classHelpers");
+
+class ActionModel {
+    constructor() {
+        this.id = null; // <number>
+        this.description = null; // <string>
+    }
+
+    toRecord(properties) {
+        assert.ok(properties, "properties<object> are required");
+        assert.ok(properties.id, "properties.id<number> is required");
+        assert.ok(properties.description, "properties.description<string> is required");
+
+        const _createValidPropertiesObject = createValidPropertiesObject.bind(this);
+
+        // Only allow existing property names to be modified
+        const record = Object.assign(
+            {},
+            this,
+            _createValidPropertiesObject(properties)
+        );
+
+        return record;
+    }
+}
+
+module.exports = ActionModel;

--- a/db/ActionRepository/index.js
+++ b/db/ActionRepository/index.js
@@ -1,0 +1,18 @@
+const assert = require("assert");
+const BaseRepository = require("../BaseRepository");
+
+class ActionRepository extends BaseRepository {
+    constructor({ knex, name, model }) {
+        assert.ok(knex, "knex is required");
+        assert.ok(name, "name<string> is required");
+        assert.ok(model, "model is required");
+
+        super();
+
+        this.knex = knex;
+        this.name = name;
+        this.model = model;
+    }
+}
+
+module.exports = ActionRepository;

--- a/db/BaseRepository/index.js
+++ b/db/BaseRepository/index.js
@@ -1,0 +1,44 @@
+const assert = require("assert");
+
+class BaseRepository {
+    hasRecord(object) {
+        assert.ok(typeof object === "object", "object<object> is required");
+
+        return this.knex(this.name)
+            .where(object)
+            .select("id")
+            .then(rows => Boolean(rows.length));
+    }
+
+    fetchAll() {
+        return this.knex(this.name)
+            .select("*")
+            .then(rows => rows.map(row => this.model.toRecord(row)));
+    }
+
+    fetchRecordById(recordId) {
+        assert.ok(typeof recordId === "number", "recordId<number> is required");
+
+        return this.knex(this.name)
+            .where("id", recordId)
+            .select()
+            .first()
+            .then(row => this.model.toRecord(row));
+    }
+
+    fetchRecordsBy(object) {
+        assert.ok(typeof object === "object", "object<object> is required");
+
+        return this.knex(this.name)
+            .where(object)
+            .then(rows => rows.map(row => this.model.toRecord(row)));
+    }
+
+    size() {
+        return this.knex(this.name)
+            .count("id as SIZE")
+            .then(total => total[0].SIZE);
+    }
+}
+
+module.exports = BaseRepository;

--- a/db/BaseWriteRepository/index.js
+++ b/db/BaseWriteRepository/index.js
@@ -1,0 +1,22 @@
+const assert = require("assert");
+const BaseRepository = require("../BaseRepository");
+
+class BaseWriteRepository extends BaseRepository {
+    insertRecord(object) {
+        assert.ok(typeof object === "object", "object<object> is required");
+
+        return this.knex.insert(object)
+            .into(this.name);
+    }
+
+    deleteRecordById(recordId) {
+        assert.ok(typeof recordId === "number", "recordId<number> is required");
+
+        return this.knex(this.name)
+            .where("id", recordId)
+            .delete()
+            .then(rowsDeleted => rowsDeleted > 0);
+    }
+}
+
+module.exports = BaseWriteRepository;

--- a/db/ExpectationRepository/ExpectationModel.js
+++ b/db/ExpectationRepository/ExpectationModel.js
@@ -1,0 +1,28 @@
+const assert = require("assert");
+const { createValidPropertiesObject } = require("../helpers/classHelpers");
+
+class ExpectationModel {
+    constructor(properties = {}) {
+        this.id = null; // <number>
+        this.description = null; // <string>
+    }
+
+    toRecord(properties) {
+        assert.ok(properties, "properties<object> are required");
+        assert.ok(properties.id, "properties.id<number> is required");
+        assert.ok(properties.description, "properties.description<string> is required");
+
+        const _createValidPropertiesObject = createValidPropertiesObject.bind(this);
+
+        // Only allow existing property names to be modified
+        const record = Object.assign(
+            {},
+            this,
+            _createValidPropertiesObject(properties)
+        );
+
+        return record;
+    }
+}
+
+module.exports = ExpectationModel;

--- a/db/ExpectationRepository/index.js
+++ b/db/ExpectationRepository/index.js
@@ -1,0 +1,18 @@
+const assert = require("assert");
+const BaseRepository = require("../BaseRepository");
+
+class ExpectationRepository extends BaseRepository {
+    constructor({ knex, name, model }) {
+        assert.ok(knex, "knex is required");
+        assert.ok(name, "name<string> is required");
+        assert.ok(model, "model is required");
+
+        super();
+
+        this.knex = knex;
+        this.name = name;
+        this.model = model;
+    }
+}
+
+module.exports = ExpectationRepository;

--- a/db/ProjectRepository/ProjectModel.js
+++ b/db/ProjectRepository/ProjectModel.js
@@ -1,0 +1,27 @@
+const assert = require("assert");
+const { createValidPropertiesObject } = require("../helpers/classHelpers");
+
+class ProjectModel {
+    constructor() {
+        this.id = null; // <number>
+        this.description = null; // <string>
+    }
+
+    toRecord(properties) {
+        assert.ok(properties.id, "properties.id<number> is required");
+        assert.ok(properties.description, "properties.description<string> is required");
+
+        const _createValidPropertiesObject = createValidPropertiesObject.bind(this);
+
+        // Only allow existing property names to be modified
+        const record = Object.assign(
+            {},
+            this,
+            _createValidPropertiesObject(properties)
+        );
+
+        return record;
+    }
+}
+
+module.exports = ProjectModel;

--- a/db/ProjectRepository/index.js
+++ b/db/ProjectRepository/index.js
@@ -1,0 +1,18 @@
+const assert = require("assert");
+const BaseWriteRepository = require("../BaseWriteRepository");
+
+class ProjectRepository extends BaseWriteRepository {
+    constructor({ knex, name, model }) {
+        assert.ok(knex, "knex is required");
+        assert.ok(name, "name<string> is required");
+        assert.ok(model, "model is required");
+
+        super();
+
+        this.knex = knex;
+        this.name = name;
+        this.model = model;
+    }
+}
+
+module.exports = ProjectRepository;

--- a/db/StepRepository/StepModel.js
+++ b/db/StepRepository/StepModel.js
@@ -1,0 +1,36 @@
+const assert = require("assert");
+const { createValidPropertiesObject } = require("../helpers/classHelpers");
+
+class StepModel {
+    constructor() {
+        this.id = null; // <number>
+        this.description = null; // <string>
+        this.action_id = null; // <number>
+        this.test_id = null; // <number>
+        this.css_selector = null; // <string>
+        this.string = null; // <string>
+        this.expectation = null; // <number>
+        this.key_code = null; // <number>
+    }
+
+    toRecord(properties) {
+        assert.ok(properties, "properties<object> are required");
+        assert.ok(properties.id, "properties.id<number> is required");
+        assert.ok(properties.description, "properties.description<string> is required");
+        assert.ok(properties.action_id, "properties.action_id<number> is required");
+        assert.ok(properties.test_id, "properties.test_id<number> is required");
+
+        const _createValidPropertiesObject = createValidPropertiesObject.bind(this);
+
+        // Only allow existing property names to be modified
+        const record = Object.assign(
+            {},
+            this,
+            _createValidPropertiesObject(properties)
+        );
+
+        return record;
+    }
+}
+
+module.exports = StepModel;

--- a/db/StepRepository/index.js
+++ b/db/StepRepository/index.js
@@ -1,0 +1,18 @@
+const assert = require("assert");
+const BaseWriteRepository = require("../BaseWriteRepository");
+
+class StepRepository extends BaseWriteRepository {
+    constructor({ knex, name, model }) {
+        assert.ok(knex, "knex is required");
+        assert.ok(name, "name<string> is required");
+        assert.ok(model, "model is required");
+
+        super();
+
+        this.knex = knex;
+        this.name = name;
+        this.model = model;
+    }
+}
+
+module.exports = StepRepository;

--- a/db/TestRepository/TestModel.js
+++ b/db/TestRepository/TestModel.js
@@ -1,0 +1,30 @@
+const assert = require("assert");
+const { createValidPropertiesObject } = require("../helpers/classHelpers");
+
+class TestModel {
+    constructor() {
+        this.id = null; // <number>
+        this.description = null; // <string>
+        this.project_id = null; // <number>
+    }
+
+    toRecord(properties) {
+        assert.ok(properties, "properties<object> are required");
+        assert.ok(properties.id, "properties.id<number> is required");
+        assert.ok(properties.description, "properties.description<string> is required");
+        assert.ok(properties.project_id, "properties.project_id<number> is required");
+
+        const _createValidPropertiesObject = createValidPropertiesObject.bind(this);
+
+        // Only allow existing property names to be modified
+        const record = Object.assign(
+            {},
+            this,
+            _createValidPropertiesObject(properties)
+        );
+
+        return record;
+    }
+}
+
+module.exports = TestModel;

--- a/db/TestRepository/index.js
+++ b/db/TestRepository/index.js
@@ -1,0 +1,18 @@
+const assert = require("assert");
+const BaseWriteRepository = require("../BaseWriteRepository");
+
+class TestRepository extends BaseWriteRepository {
+    constructor({ knex, name, model }) {
+        assert.ok(knex, "knex is required");
+        assert.ok(name, "name<string> is required");
+        assert.ok(model, "model is required");
+
+        super();
+
+        this.knex = knex;
+        this.name = name;
+        this.model = model;
+    }
+}
+
+module.exports = TestRepository;

--- a/db/helpers/classHelpers.js
+++ b/db/helpers/classHelpers.js
@@ -1,0 +1,19 @@
+const assert = require("assert");
+
+function createValidPropertiesObject (properties) {
+    assert.ok(properties, "properties<object> is required");
+
+    const validProperties = {};
+
+    Object.getOwnPropertyNames(properties).forEach((prop) => {
+        if (Object.getOwnPropertyNames(this).indexOf(prop) !== -1) {
+            validProperties[prop] = properties[prop];
+        }
+    });
+
+    return validProperties;
+}
+
+module.exports = {
+    createValidPropertiesObject,
+}

--- a/db/helpers/index.js
+++ b/db/helpers/index.js
@@ -1,0 +1,7 @@
+const paths = require("./paths");
+const classHelpers = require("./classHelpers");
+
+module.exports = {
+    paths,
+    classHelpers,
+}

--- a/db/helpers/paths.js
+++ b/db/helpers/paths.js
@@ -1,0 +1,9 @@
+const path = require("path");
+const fs = require("fs");
+
+const appDirectory = fs.realpathSync(process.cwd());
+const resolveApp = relativePath => path.resolve(appDirectory, relativePath);
+
+module.exports = {
+    db: resolveApp("db"),
+}

--- a/db/index.js
+++ b/db/index.js
@@ -1,0 +1,23 @@
+const ActionRepository = require("./ActionRepository");
+const ActionModel = require("./ActionRepository/ActionModel");
+const ExpectationRepository = require("./ExpectationRepository");
+const ExpectationModel = require("./ExpectationRepository/ExpectationModel");
+const ProjectRepository = require("./ProjectRepository");
+const ProjectModel = require("./ProjectRepository/ProjectModel");
+const StepRepository = require("./StepRepository");
+const StepModel = require("./StepRepository/StepModel");
+const TestRepository = require("./TestRepository");
+const TestModel = require("./TestRepository/TestModel");
+
+module.exports = {
+    ActionRepository,
+    ActionModel,
+    ExpectationRepository,
+    ExpectationModel,
+    ProjectRepository,
+    ProjectModel,
+    StepRepository,
+    StepModel,
+    TestRepository,
+    TestModel,
+};


### PR DESCRIPTION
Everything extends either `BaseService` or `BaseWriteService`. This is 
currently where all the methods come from and is good enough for now.